### PR TITLE
python: use sysroot when crosscompiling

### DIFF
--- a/python/python-2.7.3-xcompile.patch
+++ b/python/python-2.7.3-xcompile.patch
@@ -154,7 +154,7 @@ diff -urN Python-2.7.2/setup.py ltib/rpm/BUILD/Python-2.7.2/setup.py
              # OSX note: Don't add LIBDIR and INCLUDEDIR to building a framework
              # (PYTHONFRAMEWORK is set) to avoid # linking problems when
              # building a framework with different architectures than
-@@ -426,11 +437,14 @@
+@@ -426,11 +437,20 @@
          # lib_dirs and inc_dirs are used to search for files;
          # if a file is found in one of those directories, it can
          # be assumed that no additional -I,-L directives are needed.
@@ -171,6 +171,12 @@ diff -urN Python-2.7.2/setup.py ltib/rpm/BUILD/Python-2.7.2/setup.py
 +                '/lib', '/usr/lib',
 +                ]
 +            inc_dirs += ['/usr/include']
++ 
++        sysroot = os.getenv('SYSROOT')
++        if sysroot is not None:
++            inc_dirs.append(os.path.join(sysroot, 'usr/include'))
++            lib_dirs.append(os.path.join(sysroot, 'usr/lib'))
++ 
          exts = []
          missing = []
  


### PR DESCRIPTION
This way we get zlib etc in python.

Signed-off-by: Jari Vanhala jari.vanhala@ixonos.com
